### PR TITLE
Fix mongo version, and add instructions for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ mkdir -p code/data/db
 mkdir -p code/log
 ```
 * 2 Put your source file in the *code* directory:
-    - see https://github.com/pixelhumain/pixelhumain/blob/master/README.md
+    - See https://github.com/pixelhumain/pixelhumain/blob/master/README.md
+    - Edit the file /ph/protected/config/dbconfig.php, this line: 
+    ```
+    'server' => 'mongodb://127.0.0.1:27017/'
+    ```
+    to be:
+    ```
+    'server' => 'mongodb://mongo:27017/'
+    ```
+    Therefore it will be able to connect to the Docker image called mongo
     - use the docker image provided below
     - Your VCS / IDE / ...
 * 3 Start the containers using:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mongo:
-    image: mongo
+    image: mongo:3.4
     volumes:
       - ./code/data/db:/data/db
     ports:


### PR DESCRIPTION
Fixed mongo incompatibility.
- Latest mongo version causes this error: The 'cursor' option is required, except for aggregate with the explain argument
Check [here](https://stackoverflow.com/questions/47472688/spring-data-mongodb-the-cursor-option-is-required) for more info. 
- Also I added instructions to be able to connect properly to the mongo Docker image.